### PR TITLE
feat(sentry): use Hub from Entry's context when possible

### DIFF
--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 
@@ -11,10 +12,23 @@ import (
 )
 
 type Writer struct {
-	Encoder                   golog.Encoder
-	Hub                       *sentry.Hub
-	ErrHandler                golog.ErrorHandler
+	Encoder    golog.Encoder
+	ErrHandler golog.ErrorHandler
+
+	// Hub is the sentry Hub used for capturing events. If nil, the
+	// sentry.CurrentHub() will be used.
+	//
+	// If the context of the golog Entry to be logged contains a sentry.Hub, it
+	// will be used instead.
+	Hub *sentry.Hub
+
+	// DefaultIsException set to true means that the when this Writer is used as
+	// a writer for the stdlib `log` package, its events will be treated as
+	// Sentry errors.
 	DefaultCaptureException bool
+
+	// CaptureExceptionFromLevel is the level at which an Entry will be
+	// treated as Sentry error instead of an arbitrary message.
 	CaptureExceptionFromLevel golog.Level
 }
 
@@ -31,21 +45,36 @@ func (w *Writer) WriteEntry(e golog.Entry) {
 		return
 	}
 
+	hub := w.getHub(e.Context())
 	if e.Level() >= w.CaptureExceptionFromLevel {
-		w.Hub.CaptureException(errors.New(buf.String()))
+		hub.CaptureException(errors.New(buf.String()))
 		return
 	}
 
-	w.Hub.CaptureMessage(buf.String())
-
+	hub.CaptureMessage(buf.String())
 }
 
 func (w *Writer) Write(msg []byte) (int, error) {
+	hub := w.getHub(nil)
+
 	if w.DefaultCaptureException {
-		w.Hub.CaptureException(errors.New(string(msg)))
+		hub.CaptureException(errors.New(string(msg)))
 		return len(msg), nil
 	}
 
-	w.Hub.CaptureMessage(string(msg))
+	hub.CaptureMessage(string(msg))
 	return len(msg), nil
+}
+
+func (w *Writer) getHub(ctx context.Context) *sentry.Hub {
+	ctxHub := sentry.GetHubFromContext(ctx)
+	if ctxHub != nil {
+		return ctxHub
+	}
+
+	if w.Hub != nil {
+		return w.Hub
+	}
+
+	return sentry.CurrentHub()
 }

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -14,7 +14,7 @@ type Writer struct {
 	Encoder                   golog.Encoder
 	Hub                       *sentry.Hub
 	ErrHandler                golog.ErrorHandler
-	DefaultLevel              golog.Level
+	DefaultCaptureException bool
 	CaptureExceptionFromLevel golog.Level
 }
 
@@ -41,7 +41,7 @@ func (w *Writer) WriteEntry(e golog.Entry) {
 }
 
 func (w *Writer) Write(msg []byte) (int, error) {
-	if w.DefaultLevel >= w.CaptureExceptionFromLevel {
+	if w.DefaultCaptureException {
 		w.Hub.CaptureException(errors.New(string(msg)))
 		return len(msg), nil
 	}

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -60,7 +60,7 @@ func TestWriter(t *testing.T) {
 			Encoder:                   enc,
 			Hub:                       hub,
 			ErrHandler:                golog.DefaultErrorHandler(),
-			DefaultLevel:              golog.INFO,
+			DefaultCaptureException:   false,
 			CaptureExceptionFromLevel: golog.WARN,
 		}
 
@@ -89,7 +89,7 @@ func TestWriter(t *testing.T) {
 			Encoder:                   enc,
 			Hub:                       hub,
 			ErrHandler:                golog.DefaultErrorHandler(),
-			DefaultLevel:              golog.INFO,
+			DefaultCaptureException:   false,
 			CaptureExceptionFromLevel: golog.WARN,
 		}
 

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -21,14 +21,14 @@ var (
 
 type fakeTransport struct {
 	Message   string
-	Excpetion []sentry.Exception
+	Exception []sentry.Exception
 }
 
 func (t *fakeTransport) Configure(sentry.ClientOptions) {}
 
 func (t *fakeTransport) SendEvent(ev *sentry.Event) {
 	t.Message = ev.Message
-	t.Excpetion = ev.Exception
+	t.Exception = ev.Exception
 }
 
 func (t *fakeTransport) Flush(time.Duration) bool {
@@ -71,9 +71,9 @@ func TestWriter(t *testing.T) {
 			t.Errorf("want: %s", data)
 		}
 
-		if len(transport.Excpetion) > 0 {
+		if len(transport.Exception) > 0 {
 			t.Error("could not match exception")
-			t.Errorf("got: %v", transport.Excpetion)
+			t.Errorf("got: %v", transport.Exception)
 		}
 	})
 
@@ -94,7 +94,7 @@ func TestWriter(t *testing.T) {
 		}
 
 		w.WriteEntry(errorEntry)
-		if transport.Excpetion[0].Value != string(data) {
+		if transport.Exception[0].Value != string(data) {
 			t.Error("could not match exception")
 			t.Errorf("got: %s", transport.Message)
 			t.Errorf("want: %s", data)
@@ -102,7 +102,7 @@ func TestWriter(t *testing.T) {
 
 		if transport.Message != "" {
 			t.Error("could not match message")
-			t.Errorf("got: %v", transport.Excpetion)
+			t.Errorf("got: %v", transport.Exception)
 		}
 	})
 }


### PR DESCRIPTION
If the golog.Entry's context contains a sentry Hub, use it. If it doesn't, fallback to the hub configured for the Writer. If no hub were specified for the Writer, use the sentry.CurrentHub().

Users should keep in mind that using a hub concurrently is not supported by sentry.

I also took the chance to do some minor cleanup in the Writer struct and adding some comments.

Closes #54.