### PR TITLE
feat(datadog): add dd tracing decorator

### DIFF
--- a/datadog/tracing.go
+++ b/datadog/tracing.go
@@ -1,0 +1,32 @@
+package datadog
+
+import (
+	"strconv"
+)
+
+const (
+	TraceIDKey = "dd.trace_id"
+	SpanIDKey  = "dd.span_id"
+)
+
+func TraceIDFromHexFormat(id string) string {
+	return convertHexIDToUint(id)
+}
+
+func SpanIDFromHexFormat(id string) string {
+	return convertHexIDToUint(id)
+}
+
+func convertHexIDToUint(id string) string {
+	if len(id) < 16 {
+		return ""
+	}
+	if len(id) > 16 {
+		id = id[16:]
+	}
+	intValue, err := strconv.ParseUint(id, 16, 64)
+	if err != nil {
+		return ""
+	}
+	return strconv.FormatUint(intValue, 10)
+}

--- a/datadog/tracing_test.go
+++ b/datadog/tracing_test.go
@@ -1,0 +1,27 @@
+package datadog
+
+import (
+	"testing"
+)
+
+func TestTraceIDFromHexFormat(t *testing.T) {
+	traceID := "0ef42e66522e5a9183241106963acf99"
+	expectedTraceID := "9449696638118055833"
+
+	result := TraceIDFromHexFormat(traceID)
+
+	if result != expectedTraceID {
+		t.Errorf("expected result trace id to be %q got %q", expectedTraceID, result)
+	}
+}
+
+func TestSpanIDFromHexFormat(t *testing.T) {
+	spanID := "0102040810203040"
+	expectedSpanID := "72624976668143680"
+
+	result := SpanIDFromHexFormat(spanID)
+
+	if result != expectedSpanID {
+		t.Errorf("expected result span id to be %q got %q", expectedSpanID, result)
+	}
+}

--- a/opentelemetry/opentelemetry.go
+++ b/opentelemetry/opentelemetry.go
@@ -34,3 +34,31 @@ func SpanID(span trace.SpanContext) golog.Field {
 	const k = "span_id"
 	return golog.String(k, span.SpanID().String())
 }
+
+func CustomTraceDecoratorOption(
+	traceIDKey string,
+	traceIDTransformer func(traceID string) string,
+	spanIDKey string,
+	spanIDTransformer func(spanID string) string,
+) golog.Option {
+	return golog.OptionFunc(func(l golog.StdLogger) golog.StdLogger {
+		d := CustomTraceDecorator(traceIDKey, traceIDTransformer, spanIDKey, spanIDTransformer)
+		return l.WithDecorator(d)
+	})
+}
+
+func CustomTraceDecorator(
+	traceIDKey string,
+	traceIDTransformer func(traceID string) string,
+	spanIDKey string,
+	spanIDTransformer func(spanID string) string,
+) golog.DecoratorFunc {
+	return func(e golog.Entry) golog.Entry {
+		span := trace.SpanFromContext(e.Context()).SpanContext()
+
+		return e.With(
+			golog.String(traceIDKey, traceIDTransformer(span.TraceID().String())),
+			golog.String(spanIDKey, spanIDTransformer(span.SpanID().String())),
+		)
+	}
+}

--- a/opentelemetry/opentelemetry_test.go
+++ b/opentelemetry/opentelemetry_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/damianopetrungaro/golog"
 	. "github.com/damianopetrungaro/golog/opentelemetry"
-
 	"go.opentelemetry.io/otel"
 )
 
@@ -54,4 +53,35 @@ func TestTraceDecorator(t *testing.T) {
 			t.Error("could not match span value")
 		}
 	})
+}
+
+func TestCustomTraceDecoratorOption(t *testing.T) {
+	var e Entry = NewStdEntry(context.Background(), DEBUG, "", nil)
+	d := CustomTraceDecorator(
+		"test.trace_id",
+		func(traceID string) string {
+			return "trace_id"
+		},
+		"test.span_id",
+		func(spanID string) string {
+			return "span_id"
+		},
+	)
+	flds := d.Decorate(e).(StdEntry).Fields()
+
+	if len(flds) != 2 {
+		t.Fatal("could not match fields")
+	}
+	if flds[0].Key() != "test.trace_id" {
+		t.Error("could not match trace key")
+	}
+	if flds[1].Key() != "test.span_id" {
+		t.Error("could not match span key")
+	}
+	if flds[0].Value() != "trace_id" {
+		t.Error("could not match trace value")
+	}
+	if flds[1].Value() != "span_id" {
+		t.Error("could not match span value")
+	}
 }


### PR DESCRIPTION
# Description

Adds a decorator that extracts and converts traces from OpenTelemetry format to Data Dog format according to [DD docs](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=go).
