### PR TITLE
chore: add section for who uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ The `context.Context` in Go is usually the holder for tracing information and
 embedding one of the decorators available to the logger plugs this behavior for free
 in all the places where the logger is used.
 
+## Who uses Golog?
+
+* [Pento](https://www.pento.io) - Used in multiple production services.
+
+
 ## Examples
 
 Based on your needs, you can find some presets available.


### PR DESCRIPTION
This PR adds a smalle section with information of who uses golog. Also adds Pento to that list.